### PR TITLE
fix: Add removerFactory to dependencies of useMemo in RenTable component

### DIFF
--- a/src/MyPractice/RenTable.jsx
+++ b/src/MyPractice/RenTable.jsx
@@ -161,7 +161,7 @@ function RenTab(props) {
         }
       }
     ],
-    []
+    [removerFactory]
   );
 
   const {


### PR DESCRIPTION
Previously, the RenTable component was using the useMemo hook with a function that relies on the removerFactory object, which was not included in the dependency array. 

This could lead to unexpected behavior in certain cases. This fix adds removerFactory to the dependencies of useMemo to ensure that the function is always using the latest version of the object.